### PR TITLE
devdraw/wayland.c: prevent divide-by-zero in scroll repeat

### DIFF
--- a/src/cmd/devdraw/wayland.c
+++ b/src/cmd/devdraw/wayland.c
@@ -448,8 +448,9 @@ static void wl_callback_done(void *data, struct wl_callback *wl_callback, uint32
 		wl->repeat_scroll_count--;
 		if (wl->repeat_scroll_count == 0) {
 			wl->repeat_scroll_button = 0;
+		} else {
+			wl->repeat_scroll_next_ms = time + scroll_repeat_ms/wl->repeat_scroll_count;
 		}
-		wl->repeat_scroll_next_ms = time + scroll_repeat_ms/wl->repeat_scroll_count;
 	}
 
 	qunlock(&wayland_lock);


### PR DESCRIPTION
remedies devdraw hitting SIGFPE with sufficiently vigorous scrollwheel usage on high refresh rate screens

btw thank you so much for your work on this thus far! you are officially the reason i can comfortably experiment with wayland. do you have any plans to propose your branch to upstream?