### PR TITLE
Only register repeat callbacks when repeat active

### DIFF
--- a/src/cmd/devdraw/wayland.c
+++ b/src/cmd/devdraw/wayland.c
@@ -164,7 +164,7 @@ static void registry_global(void *data, struct wl_registry *wl_registry,
 			&xdg_wm_base_interface, 1);
 
 	} else if (strcmp(interface, wl_seat_interface.name) == 0) {
-		wl_seat = wl_registry_bind(wl_registry, name, &wl_seat_interface, 1);
+		wl_seat = wl_registry_bind(wl_registry, name, &wl_seat_interface, 4);
 
 	} else if (strcmp(interface, wl_data_device_manager_interface.name) == 0) {
 		wl_data_device_manager = wl_registry_bind(wl_registry, name, &wl_data_device_manager_interface, 2);
@@ -844,7 +844,6 @@ void wl_keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
 	qunlock(&wayland_lock);
 }
 
-// Currently we don't bind the keyboard with the correct version to get this event.
 void wl_keyboard_repeat_info(void *data, struct wl_keyboard *wl_keyboard,
 	int32_t rate, int32_t delay) {
 	DEBUG("wl_keyboard_repeat_info(rate=%d, delay=%d)\n",


### PR DESCRIPTION
When debugging using WAYLAND_DEBUG=1, the constant callbacks for key & scroll repeat made it difficult to read the debug logs. This change only registers callbacks if the key is pressed or scrolling is active. I've been using it for a month or so on Sway and it seems to work.

It will also respect the repeat info sent by the compositor, but I'm not sure if/how we tell the compositor we're interested in that request.

I split the callback for scroll repeat out and tried to leave the logic untouched because I don't use a touchpad with inertial scrolling. Hopefully it's unchanged.

The logic for key repeat is reworked a bit, and no longer depends on the callback rate (which I think is related to the screen refresh rate) being faster than the key repeat rate.